### PR TITLE
build: Fix multiple definitions of hlptim1

### DIFF
--- a/Projects/Applications/FreeRTOS/FreeRTOS_LoRaWAN/Core/Inc/main.h
+++ b/Projects/Applications/FreeRTOS/FreeRTOS_LoRaWAN/Core/Inc/main.h
@@ -99,7 +99,7 @@ void Error_Handler(void);
 #define PROB4_Pin GPIO_PIN_10
 #define PROB4_GPIO_Port GPIOB
 /* USER CODE BEGIN Private defines */
-LPTIM_HandleTypeDef hlptim1;
+extern LPTIM_HandleTypeDef hlptim1;
 
 /* USER CODE END Private defines */
 

--- a/Projects/Applications/FreeRTOS/FreeRTOS_LoRaWAN_AT/Core/Inc/main.h
+++ b/Projects/Applications/FreeRTOS/FreeRTOS_LoRaWAN_AT/Core/Inc/main.h
@@ -99,7 +99,7 @@ void Error_Handler(void);
 #define PROB4_Pin GPIO_PIN_10
 #define PROB4_GPIO_Port GPIOB
 /* USER CODE BEGIN Private defines */
-LPTIM_HandleTypeDef hlptim1;
+extern LPTIM_HandleTypeDef hlptim1;
 
 /* USER CODE END Private defines */
 

--- a/Projects/Applications/FreeRTOS/FreeRTOS_LowPower/Core/Inc/main.h
+++ b/Projects/Applications/FreeRTOS/FreeRTOS_LowPower/Core/Inc/main.h
@@ -59,7 +59,7 @@ void Error_Handler(void);
 
 /* Private defines -----------------------------------------------------------*/
 /* USER CODE BEGIN Private defines */
-LPTIM_HandleTypeDef hlptim1;
+extern LPTIM_HandleTypeDef hlptim1;
 /* USER CODE END Private defines */
 
 #ifdef __cplusplus


### PR DESCRIPTION
Make `LPTIM_HandleTypeDef hlptim1;` definition external in Core/Inc/main.h for FreeRTOS projects.